### PR TITLE
[AWSCloudSearchHelper] Added 'highlight' parameter to RunDocumentSear…

### DIFF
--- a/AWSHelpers/AWSCloudSearchHelper.cs
+++ b/AWSHelpers/AWSCloudSearchHelper.cs
@@ -252,9 +252,10 @@ namespace AWSHelpers
         /// <param name="size">The size of the result set to be returned</param>
         /// <param name="expressions">A list of expressions to be calculated and returned with the results</param>
         /// <param name="facets">The "facets" parameter (for data grouping)</param>
+        /// <param name="highlight">The highlight field to be used in JSON format</param>
         /// <param name="returnFields">List of fields to be returned. By default, all return-enabled fields are returned.</param>
         /// <returns></returns>
-        public bool RunDocumentSearch (string searchQuery, string filterQuery = "", string cursor = "", string parser = "simple", int start = 0, int size = 10, List<AWSCloudSearchExpressionDefinition> expressions = null, List<AWSCloudSearchFacetFieldDefinition> facets = null, List<string> returnFields = null, string queryOptions = "", string sort = "")
+        public bool RunDocumentSearch(string searchQuery, string filterQuery = "", string cursor = "", string parser = "simple", int start = 0, int size = 10, List<AWSCloudSearchExpressionDefinition> expressions = null, List<AWSCloudSearchFacetFieldDefinition> facets = null, List<string> returnFields = null, string queryOptions = "", string sort = "", string highlight = "")
         {
             ClearErrorInfo ();
             ClearSearchResults ();
@@ -329,6 +330,11 @@ namespace AWSHelpers
                 if (!String.IsNullOrWhiteSpace(sort))
                 {
                     searchRequest.Sort = sort;
+                }
+
+                if (!String.IsNullOrWhiteSpace(highlight))
+                {
+                    searchRequest.Highlight = highlight;
                 }
 
                 SearchResponse searchResponse = CloudSearchClient.Search (searchRequest);


### PR DESCRIPTION
There are some processes require "highlight" feature. Therefore, it's necessary to implement it at RunDocumentSearch method.